### PR TITLE
Fix wrong RTT calculation in TIMELY

### DIFF
--- a/src/applications/model/seq-ts-header.cc
+++ b/src/applications/model/seq-ts-header.cc
@@ -36,6 +36,8 @@ SeqTsHeader::SeqTsHeader()
       m_ts(Simulator::Now().GetTimeStep())
 {
     NS_LOG_FUNCTION(this);
+    if (IntHeader::mode == 1)
+        ih.ts = Simulator::Now().GetTimeStep();
 }
 
 void


### PR DESCRIPTION
Refer to: https://github.com/inet-tub/ns3-datacenter/blob/master/simulator/ns-3.39/src/network/utils/seq-ts-header.cc#L37-L38